### PR TITLE
Add argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ Calling fritzBoxShell.sh using environment variables could look like this:
 BoxUSER=YourUser BoxPW=YourPassword WebPW=YourPassword ./fritzBoxShell.sh <ACTION> <PARAMETER>
 ```
 
+## Arguments/Enviroments
+
+You can use variables or arguments. However, arguments are visible in the process list and are therefore not recommended for passwords.
+
+| Enviroment | Argument | Dicreption |
+|---|---|---|
+| BoxIP | --boxip | IP or DNS of FritzBox |
+| BoxUSER | --boxuser | Username |
+| BoxPW | --boxpw | Login password for user. |
+| WebPW | --webpw | This is the web password which is needed for sending HTTP requests. Therefore only the web password is needed without an username. |
+| RepeaterIP | --repeaterip | IP or DNS of FritzRepeater |
+| RepeaterUSER | --repeateruser | Usually on Fritz!Repeater no User is existing. Can be left empty. |
+| RepeaterPW | --repeaterpw | Password for user. |
+
 ## Usage
 
 Just start the script and add the action and parameters:

--- a/fritzBoxShell.sh
+++ b/fritzBoxShell.sh
@@ -35,6 +35,51 @@ source "$DIRECTORY/fritzBoxShellConfig.sh"
 #*********************** SCRIPT ***********************#
 #******************************************************#
 
+# Parsing arguments
+# Example:
+# ./fritzBoxShell.sh --boxip 192.168.178.1 --boxuser foo --boxpw baa WLAN_2G 1
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+		--boxip)
+    BoxIP="$2"
+    shift ; shift
+    ;;
+		--boxuser)
+    BoxUSER="$2"
+    shift ; shift
+    ;;
+		--boxpw)
+    BoxPW="$2"
+    shift ; shift
+    ;;
+		--webpw)
+    WebPW="$2"
+    shift ; shift
+    ;;
+		--repeaterip)
+    RepeaterIP="$2"
+    shift ; shift
+    ;;
+		--repeateruser)
+    RepeaterUSER="$2"
+    shift ; shift
+    ;;
+		--repeaterpw)
+    RepeaterPW="$2"
+    shift ; shift
+    ;;
+		*)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+  esac
+done
+
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
 # Storing shell parameters in variables
 # Example:
 # ./fritzBoxShell.sh WLAN_2G 1


### PR DESCRIPTION
Hello,
i want use this script to monitor the FritzBox over [Zabbix](https:/zabbix.com/). But the [Externel Script](https://www.zabbix.com/documentation/current/manual/config/items/itemtypes/external) logic can't handle environment variables.
Befor i write a wrapper-script that handle the arguments and set this to environment variables, i think it's better when the source script become a new feature.
I added the parsing function and added a warning to the README.md because the password could be leaked through the process list.
For improvement suggestions and ideas I am open, but I would be very happy if the script is extended by arguments.