### PR TITLE
Add output format and filter and extend online help

### DIFF
--- a/fritzBoxShell.sh
+++ b/fritzBoxShell.sh
@@ -799,6 +799,21 @@ DisplayArguments() {
 	echo "| VERSION        |                        | Version of the fritzBoxShell.sh                                         |"
 	echo "|----------------|------------------------|-------------------------------------------------------------------------|"
 	echo ""
+  cat <<END
+Supported command line options and their related environment value:
+  --boxip <IP address>      <-> BoxIP="<IP address>"
+  --boxuser <user>          <-> BoxUSER="<user>"
+  --boxpw <password>        <-> BoxPW="<password>"
+  --repeaterip <IP address> <-> RepeaterIP="<IP address>"
+  --repeateruser <user>     <-> RepeaterUSER="<user>"
+  --repeaterpw <password>   <-> RepeaterPW="<password>"
+
+Supported optional output format/filter:
+  -O|outputformat influx|graphite
+  -F|outputfilter <regular expression>
+END
+
+  exit 1
 }
 
 # Check if an argument was supplied for shell script

--- a/fritzBoxShell.sh
+++ b/fritzBoxShell.sh
@@ -84,6 +84,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 # handle output format as wrapper to self
 if [ -n "$OutputFormat" ]; then
   # call self again with arguments
+  export BoxIP BoxUSER BoxPW RepeaterIP RepeaterUSER RepeaterPW
   output=$($0 $*)
   rc=$?
 

--- a/fritzBoxShell.sh
+++ b/fritzBoxShell.sh
@@ -841,3 +841,5 @@ else
 	else DisplayArguments
 	fi
 fi
+
+# vim: tabstop=2 smartindent shiftwidth=2 expandtab!

--- a/fritzBoxShell.sh
+++ b/fritzBoxShell.sh
@@ -113,6 +113,7 @@ if [ -n "$OutputFormat" ]; then
       ;;
     *)
       # unsupported OutputFormat
+      echo "$(basename "$0"): error occured, '-O|--outputformat ...' active, but format not supported: $OutputFormat" >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
Hi, thank you first for your script, was able to use this on QNAP with InfluxDB and Telegraf!

This PR contains "outputformat" and "outputfilter" option to avoid requesting additional external wrapper scripts like mentioned here: https://github.com/jhubig/FritzBoxShell/wiki/Example-use-cases:-Telegraf

It was implanted by "minimal invasion" to avoid major changes in the code on several parts because of the current structure. In case "outputformat" is active, it's simply calling itself again after parsing the options and reformats the output.

Currently supported: "influx" and "graphite"-like output

It also extends the online help.