### PR TITLE
Fix WLAN_5G test case

### DIFF
--- a/fritzBoxShellTest.sh
+++ b/fritzBoxShellTest.sh
@@ -14,7 +14,7 @@ DIRECTORY=$(cd "$dir" && pwd)
 source "$DIRECTORY/fritzBoxShellConfig.sh"
 
 ## declare an array variable
-declare -a services=("WLAN_2G"   "WLAN_2G" "WLAN_5G"    "WLAN_2G" "WLAN"  "LAN"   "DSL"   "WAN"   "LINK"  "IGDWAN" "IGDDSL" "IGDIP" "TAM")
+declare -a services=("WLAN_2G"   "WLAN_2G" "WLAN_5G"    "WLAN_5G" "WLAN"  "LAN"   "DSL"   "WAN"   "LINK"  "IGDWAN" "IGDDSL" "IGDIP" "TAM")
 declare -a actions=("STATISTICS" "STATE"   "STATISTICS" "STATE"   "STATE" "STATE" "STATE" "STATE" "STATE" "STATE"  "STATE"  "STATE" "0 GetInfo")
 declare -a minwords=(3           5         3            5         9       1       1       1       1       1        1        1       5      )
 


### PR DESCRIPTION
fixing a typo/copy error where WLAN_2G STATE was executed twice, but no WLAN_5G STATE test case existed